### PR TITLE
feat: Implement full auth flow and dashboard shell

### DIFF
--- a/lib/data/services/auth_service.dart
+++ b/lib/data/services/auth_service.dart
@@ -25,6 +25,53 @@ class AuthService {
   };
 
 
+
+  // --- NEW: DUMMY LOGOUT LOGIC ---
+  Future<void> logout() async {
+    await Future.delayed(const Duration(milliseconds: 500)); // Simulate network delay
+
+    // MEHEDI-TODO: This will be replaced with a single Firebase call.
+    // Use `await FirebaseAuth.instance.signOut();`
+    // No need to handle navigation here; that's the UI's job.
+    
+    print('Dummy user logged out.');
+  }
+
+
+// --- NEW: DUMMY FORGOT PASSWORD LOGIC ---
+  Future<void> forgotPassword(String email) async {
+    await Future.delayed(const Duration(seconds: 1)); // Simulate network delay
+
+    // MEHEDI-TODO: This entire block will be replaced with a single Firebase call.
+    // Use `await FirebaseAuth.instance.sendPasswordResetEmail(email: email);`
+    // You should wrap it in a try-catch block to handle potential Firebase
+    // errors, like 'user-not-found'.
+    
+    if (_users.any((user) => user.email == email)) {
+      // In our dummy version, we just print to the console.
+      print('Password reset link sent to $email');
+    } else {
+      // Simulate a "user not found" error.
+      throw Exception('No user found for that email.');
+    }
+  }
+
+
+// --- NEW: METHOD TO CHECK FOR EXISTING ADMIN ---
+  Future<bool> adminExists() async {
+    await Future.delayed(const Duration(milliseconds: 500)); // Simulate network delay
+
+    // MEHEDI-TODO: Replace this dummy logic with a real Firestore query.
+    // You will need to query the 'users' collection to see if any document
+    // has a 'role' field equal to 'admin'.
+    // Example Query:
+    // final query = await firestore.collection('users').where('role', isEqualTo: 'admin').limit(1).get();
+    // return query.docs.isNotEmpty;
+    
+    // The dummy logic simply checks our in-memory list.
+    return _users.any((user) => user.role == UserRole.admin);
+  }
+
   // --- DUMMY LOGIN LOGIC ---
   Future<AppUser> login(String email, String password) async {
     await Future.delayed(const Duration(seconds: 1)); // Simulate network delay

--- a/lib/screens/auth/forgot_password_screen.dart
+++ b/lib/screens/auth/forgot_password_screen.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import '../../data/services/auth_service.dart';
+
+class ForgotPasswordScreen extends StatefulWidget {
+  const ForgotPasswordScreen({super.key});
+
+  @override
+  State<ForgotPasswordScreen> createState() => _ForgotPasswordScreenState();
+}
+
+class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  bool _isLoading = false;
+  String? _message;
+  bool _isError = false;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _sendResetLink() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    setState(() {
+      _isLoading = true;
+      _message = null;
+      _isError = false;
+    });
+
+    try {
+      await AuthService.instance.forgotPassword(_emailController.text.trim());
+      if (mounted) {
+        setState(() {
+          _message = 'Password reset link sent! Please check your email.';
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _message = e.toString().replaceFirst('Exception: ', '');
+          _isError = true;
+        });
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Reset Password')),
+      body: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const Text(
+                'Enter your email address and we will send you a link to reset your password.',
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 24),
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(
+                  labelText: 'Email',
+                  border: OutlineInputBorder(),
+                  prefixIcon: Icon(Icons.email),
+                ),
+                keyboardType: TextInputType.emailAddress,
+                validator: (value) {
+                  if (value == null || value.isEmpty) return 'Please enter an email';
+                  if (!RegExp(r'\S+@\S+\.\S+').hasMatch(value)) return 'Please enter a valid email';
+                  return null;
+                },
+              ),
+              const SizedBox(height: 24),
+              if (_message != null)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 16.0),
+                  child: Text(
+                    _message!,
+                    style: TextStyle(color: _isError ? Colors.red : Colors.green),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              _isLoading
+                  ? const Center(child: CircularProgressIndicator())
+                  : ElevatedButton(
+                      onPressed: _sendResetLink,
+                      child: const Text('Send Reset Link'),
+                    ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/dashboard/admin_dashboard_screen.dart
+++ b/lib/screens/dashboard/admin_dashboard_screen.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import '../../data/models/user_model.dart'; // Import this to use the UserRole enum
+import 'dashboard_screen.dart'; // Import the main layout shell
+
+class AdminDashboardScreen extends StatelessWidget {
+  const AdminDashboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // NO Scaffold or AppBar here!
+    // This is the unique content for the admin.
+    final adminContent = Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Text(
+            'Welcome, Admin!',
+            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 20),
+          ElevatedButton(
+            onPressed: () {
+              // TODO: Navigate to user management screen
+            },
+            child: const Text('Manage Users'),
+          )
+        ],
+      ),
+    );
+
+    // Now, wrap the unique content with the common DashboardScreen layout.
+    // This provides the AppBar and the Drawer (sidebar).
+    return DashboardScreen(
+      title: 'Admin Dashboard',
+      body: adminContent,
+      userRole: UserRole.admin, // Pass the role to the sidebar
+    );
+  }
+}

--- a/lib/screens/dashboard/dashboard_screen.dart
+++ b/lib/screens/dashboard/dashboard_screen.dart
@@ -1,20 +1,31 @@
 import 'package:flutter/material.dart';
+import '../../widgets/sidebar.dart'; // We will create this reusable sidebar widget
+import '../../data/models/user_model.dart';
 
 class DashboardScreen extends StatelessWidget {
-  const DashboardScreen({super.key});
+  final Widget body; // The "picture" to display inside the frame
+  final String title; // The title for the AppBar
+  final UserRole userRole; // <-- ADD THE userRole PROPERTY
+  const DashboardScreen({super.key,
+         required this.body,
+        required this.title,
+        required this.userRole,
+
+
+        });
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Dashboard'),
+        title: Text(title),
+        backgroundColor: Colors.deepPurple,
+        foregroundColor: Colors.white,
       ),
-      body: const Center(
-        child: Text(
-          'Welcome! You are logged in.',
-          style: TextStyle(fontSize: 24),
-        ),
-      ),
+      /// MUBIN/AZROF-TODO: The sidebar will be built here and will show different
+      // options based on the user's role (which you can pass down as a parameter).
+      drawer: AppSidebar(userRole: userRole), // <-- REMOVED 'const' FROM HERE
+      body: body,
     );
   }
 }

--- a/lib/screens/dashboard/staff_dashboard_screen.dart
+++ b/lib/screens/dashboard/staff_dashboard_screen.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import '../../data/models/user_model.dart'; // Import this to use the UserRole enum
+import 'dashboard_screen.dart'; // Import the main layout shell
+
+
+class StaffDashboardScreen extends StatelessWidget {
+  const StaffDashboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // This is the unique content for the staff user.
+    final staffContent = const Center(
+      child: Text(
+        'Welcome, Staff!',
+        style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+      ),
+    );
+
+    // Wrap the content with the common layout shell.
+    return DashboardScreen(
+      title: 'Staff Dashboard',
+      body: staffContent,
+      userRole: UserRole.staff, // Pass the role to the sidebar
+    );
+  }
+}

--- a/lib/widgets/sidebar.dart
+++ b/lib/widgets/sidebar.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import '../data/models/user_model.dart';
+import '../data/services/auth_service.dart'; // Import AuthService
+import '../screens/auth/login_screen.dart'; // Import LoginScreen for navigation
+
+class AppSidebar extends StatelessWidget {
+  final UserRole userRole;
+
+  const AppSidebar({super.key, required this.userRole});
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: ListView(
+        padding: EdgeInsets.zero,
+        children: <Widget>[
+          UserAccountsDrawerHeader(
+            accountName: Text(
+              userRole == UserRole.admin ? 'Admin User' : 'Staff User',
+              style: const TextStyle(fontWeight: FontWeight.bold),
+            ),
+            accountEmail: Text(
+              userRole == UserRole.admin ? 'admin@app.com' : 'staff@app.com',
+            ),
+            currentAccountPicture: const CircleAvatar(
+              backgroundColor: Colors.white,
+              child: Icon(Icons.person, size: 40, color: Colors.deepPurple),
+            ),
+            decoration: const BoxDecoration(
+              color: Colors.deepPurple,
+            ),
+          ),
+          ListTile(
+            leading: const Icon(Icons.dashboard),
+            title: const Text('Dashboard'),
+            onTap: () {
+              Navigator.pop(context);
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.inventory_2),
+            title: const Text('Products'),
+            onTap: () {
+              Navigator.pop(context);
+            },
+          ),
+          const Divider(),
+          if (userRole == UserRole.admin)
+            ListTile(
+              leading: const Icon(Icons.people),
+              title: const Text('Manage Users'),
+              onTap: () {
+                Navigator.pop(context);
+              },
+            ),
+          // --- UPDATED: LOGOUT BUTTON LOGIC ---
+          ListTile(
+            leading: const Icon(Icons.logout),
+            title: const Text('Logout'),
+            onTap: () async {
+              // AZROF-NOTE: This is the implementation for logging the user out.
+              // MUBIN-NOTE: This shows how the UI calls the service layer to perform an action.
+              await AuthService.instance.logout();
+              
+              if (context.mounted) {
+                // Navigate back to the login screen and remove all previous routes.
+                // This is important so the user can't press the back button to get
+                // back into the dashboard after logging out.
+                Navigator.of(context).pushAndRemoveUntil(
+                  MaterialPageRoute(builder: (context) => const LoginScreen()),
+                  (Route<dynamic> route) => false, // This predicate removes all routes.
+                );
+              }
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -72,6 +88,11 @@ packages:
     version: "5.0.0"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -139,6 +160,102 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: bd14436108211b0d4ee5038689a56d4ae3620fd72fd6036e113bf1345bc74d9e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.13"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -208,6 +325,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.0.2"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
 sdks:
   dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,8 @@ dependencies:
   flutter:
     sdk: flutter
 
+  # Add the line below this comment if it's missing
+  shared_preferences: ^2.2.3 # Or the latest version
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8


### PR DESCRIPTION
### Summary
This pull request delivers a complete, end-to-end authentication experience and establishes the main application layout. It builds upon the initial login/signup screens by adding key user-friendly features and the foundational navigation structure.

The app now fully supports a dummy authentication lifecycle, including sign-up restrictions, password recovery, "Remember Me," and logout. It also correctly navigates users to role-specific dashboards (Admin/Staff) which use a shared layout shell and a dynamic sidebar.

### Key Features Implemented
- **Remember Me:** Saves the user's email to local storage on login if the box is checked.
- **Role-Based Dashboards:** Navigates users to a unique `AdminDashboardScreen` or `StaffDashboardScreen` based on their role.
- **Dashboard Layout & Sidebar:** Creates a reusable `DashboardScreen` shell that provides a consistent AppBar and a dynamic `AppSidebar` which shows/hides options based on user role.
- **Admin Creation Restriction:** The sign-up screen now dynamically checks if an admin account already exists and will not show "Admin" as a role option if one does.
- **Forgot Password:** A dummy UI flow for resetting a password. **Note: The actual password reset email is not sent; this is a placeholder for the backend implementation.**
- **Logout:** A functional logout button in the sidebar that securely navigates the user back to the login screen.

### How to Test
1.  Run the app. The "Admin" option should be disabled in the Sign-Up role dropdown because a default admin already exists.
2.  Use the "Forgot Password" feature for `admin@app.com`. It should show a success message.
3.  Log in as `admin@app.com` (password: `password`) with "Remember Me" checked. You should be taken to the Admin Dashboard.
4.  Open the sidebar. You should see the "Manage Users" option.
5.  Close and restart the app. The email `admin@app.com` should be pre-filled.
6.  Log out using the sidebar button. You should be returned to the login screen.

### For the Reviewers
- @Mehedi-86 All new authentication logic in `auth_service.dart` has clear `MEHEDI-TODO` comments where your Firebase implementation is needed. **Specifically, you will need to implement the real "Forgot Password" logic using `sendPasswordResetEmail`, as the current version is just a UI placeholder.**
- @MMI122  The dashboard shell and sidebar are now in place. You are unblocked to start building the content for the dashboard metrics, which will be placed inside the `AdminDashboardScreen` and `StaffDashboardScreen` widgets.